### PR TITLE
Bug Fix | #128 | BlockTxs Fetching Twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fix FireFox invalid date filters #145
 - Fix Metadata loading in multiple components and looping when failing #147
+- Fix BlockTxs API call happening 2x #128
 
 ## 2.0.2
 

--- a/src/Pages/Block/Components/BlockTxs.js
+++ b/src/Pages/Block/Components/BlockTxs.js
@@ -20,7 +20,7 @@ const BlockTxs = () => {
       page: tableCurrentPage,
       count: tableCount,
     });
-  }, [getTableData, pageBlockHeight, tablePages, tableCurrentPage, tableCount]);
+  }, [getTableData, pageBlockHeight, tableCurrentPage, tableCount]);
 
   // Table header values in order
   const tableHeaders = [

--- a/src/redux/reducers/txsReducer.js
+++ b/src/redux/reducers/txsReducer.js
@@ -32,6 +32,7 @@ export const initialState = {
   // Txs for a specific block
   txsByBlock: [],
   txsByBlockLoading: false,
+  txsByBlockPages: 0,
   // Txs for a specific wallet address
   txsByAddress: [],
   txsByAddressLoading: false,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before submitting, please review the checkboxes.
v    If a checkbox is n/a - please still include it but add a note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
txsByBlockPages was missing in the reducer as a default value so I added it.  Removed the total pages check in useEffect for blockTxs, no reason for it to check and cause a re-render/fetch
closes: #128 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer