### PR TITLE
Fix the rounding to 3 decima places on hash USD price on dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 - Fixed the spelling issue on account #203
+- Fixed the rounding to 3 decimal places on hash USD price on dashboard #202
 
 ### Features
 

--- a/src/Pages/Dashboard/Components/BlockSpotlight.js
+++ b/src/Pages/Dashboard/Components/BlockSpotlight.js
@@ -162,7 +162,7 @@ const BlockSpotlight = () => {
             </DataCard>
             <DataCard icon="PRICE" title="Latest Price">
               {`$${formatDenom(dailyPrice.latestDisplayPricePerDisplayUnit, 'USD', {
-                decimal: 2,
+                decimal: 3,
               })} (${priceChangePercent})`}
             </DataCard>
             <DataCard icon="LINE_CHART" title="Market Cap">


### PR DESCRIPTION
## Description

Fixed the rounding to 3 decimal places on hash USD price on the dashboard

closes: #202 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer