### PR TITLE
Update reducers to allow for null values, other minor fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fixed Tx validators links to link to validators not accounts #182
 - Fixed logic to display undelegates #230
+- Fixed to handle null values in asset/account pricing #232
 
 ### Features
 

--- a/src/Components/Navigation/Components/NavStandard.js
+++ b/src/Components/Navigation/Components/NavStandard.js
@@ -18,10 +18,10 @@ const NavigationWrapper = styled.div`
   left: 0;
   margin: 0 auto;
   width: 100%;
-  padding: 15px 10%;
+  padding: 15px 15px;
   background: ${({ theme }) => theme.BACKGROUND_NAV};
   @media ${breakpoints.down('lg')} {
-    padding: 10px 20px;
+    padding: 10px 15px;
   }
 `;
 
@@ -61,7 +61,7 @@ const DropdownUL = styled.ul`
   list-style: none;
   margin-left: -5px;
   padding: 20px 0 0 0;
-  @media ${breakpoints.down('lg')} {
+  @media ${breakpoints.down('xl')} {
     padding: 15px 0 0 0;
   }
   ${NavSectionLI}:hover & {

--- a/src/Pages/Accounts/Components/AccountSpotlight.js
+++ b/src/Pages/Accounts/Components/AccountSpotlight.js
@@ -62,7 +62,7 @@ const AccountSpotlight = () => {
     fontColor: 'FONT_WHITE',
     data: [
       {
-        //title: 'Assets Under Management',
+        title: '',
         value: 'Total value of all account assets under management (AUM)',
       },
     ],

--- a/src/Pages/Tx/Components/TxMsgs.js
+++ b/src/Pages/Tx/Components/TxMsgs.js
@@ -167,7 +167,7 @@ const TxMsgs = () => {
         )
       }
     >
-      {(txMsgsLoading && !infoExists) || (chaincodePrefixesLoading && <Loading />)}
+      {((txMsgsLoading && !infoExists) || chaincodePrefixesLoading) && <Loading />}
       {infoExists ? (
         <InfiniteScroll loading={txMsgsLoading} onLoadMore={loadMsgs} totalPages={txMsgsPages}>
           {({ sentryRef, hasNextPage }) => (

--- a/src/redux/reducers/accountsReducer.js
+++ b/src/redux/reducers/accountsReducer.js
@@ -86,15 +86,18 @@ const reducer = handleActions(
         accountAssetsLoading: false,
         accountAssets: accountAssets.map(result => ({
           ...result,
-          pricePerToken: formatDenom(result.pricePerToken.amount, result.pricePerToken.denom, {
-            decimal: 2,
-            minimumFractionDigits: 2,
-          }),
-          totalBalancePrice: formatDenom(
-            result.totalBalancePrice.amount,
-            result.totalBalancePrice.denom,
-            { decimal: 2, minimumFractionDigits: 2 }
-          ),
+          pricePerToken: result.pricePerToken
+            ? formatDenom(result.pricePerToken.amount, result.pricePerToken.denom, {
+                decimal: 2,
+                minimumFractionDigits: 2,
+              })
+            : '-- --',
+          totalBalancePrice: result.totalBalancePrice
+            ? formatDenom(result.totalBalancePrice.amount, result.totalBalancePrice.denom, {
+                decimal: 2,
+                minimumFractionDigits: 2,
+              })
+            : '-- --',
         })),
         accountAssetsPages,
       };

--- a/src/redux/reducers/assetsReducer.js
+++ b/src/redux/reducers/assetsReducer.js
@@ -129,16 +129,19 @@ const reducer = handleActions(
         assets: assets.map(result => ({
           ...result,
           lastTxTimestamp: result.lastTxTimestamp === 'null' ? null : result.lastTxTimestamp,
-          pricePerToken: formatDenom(
-            result.supply.pricePerToken.amount,
-            result.supply.pricePerToken.denom,
-            { decimal: 2, minimumFractionDigits: 2 }
-          ),
-          totalBalancePrice: formatDenom(
-            result.supply.totalBalancePrice.amount,
-            result.supply.totalBalancePrice.denom,
-            { decimal: 2, minimumFractionDigits: 2 }
-          ),
+          pricePerToken: result.supply.pricePerToken
+            ? formatDenom(result.supply.pricePerToken.amount, result.supply.pricePerToken.denom, {
+                decimal: 2,
+                minimumFractionDigits: 2,
+              })
+            : '-- --',
+          totalBalancePrice: result.supply.totalBalancePrice
+            ? formatDenom(
+                result.supply.totalBalancePrice.amount,
+                result.supply.totalBalancePrice.denom,
+                { decimal: 2, minimumFractionDigits: 2 }
+              )
+            : '-- --',
         })),
         assetsPages,
         assetsLoading: false,
@@ -163,16 +166,20 @@ const reducer = handleActions(
       return {
         ...state,
         assetInfo,
-        pricePerToken: formatDenom(
-          assetInfo.supply.pricePerToken.amount,
-          assetInfo.supply.pricePerToken.denom,
-          { decimal: 2, minimumFractionDigits: 2 }
-        ),
-        totalBalancePrice: formatDenom(
-          assetInfo.supply.totalBalancePrice.amount,
-          assetInfo.supply.totalBalancePrice.denom,
-          { decimal: 2, minimumFractionDigits: 2 }
-        ),
+        pricePerToken: assetInfo.supply.pricePerToken
+          ? formatDenom(
+              assetInfo.supply.pricePerToken.amount,
+              assetInfo.supply.pricePerToken.denom,
+              { decimal: 2, minimumFractionDigits: 2 }
+            )
+          : '-- --',
+        totalBalancePrice: assetInfo.supply.totalBalancePrice
+          ? formatDenom(
+              assetInfo.supply.totalBalancePrice.amount,
+              assetInfo.supply.totalBalancePrice.denom,
+              { decimal: 2, minimumFractionDigits: 2 }
+            )
+          : '-- --',
         assetInfoLoading: false,
       };
     },


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before submitting, please review the checkboxes.
v    If a checkbox is n/a - please still include it but add a note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Per provenance-io/explorer-service#285, service now sends a null value to differentiate between no pricing and a price of $0.00. This PR fixes the account and asset reducers to handle null values.

Other minor issues fixed:
 Update nav bar to avoid super small Provenance logo
 Update dropdown padding for 'xl' rendering
 Add blank title to AUM info popup note to avoid warning
 Adjust parenthesis in TxMsgs logic to avoid ReactNode warning for Content component.

closes: #232 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [X] Targeted PR against correct branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [X] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer