### PR TITLE
Add pagination to account assets, correct red/green text on dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add date-defined chart for dlob price history #189
 - Move 24-hr volume block to hash dashboard #236
 - Make y-axis dynamic based on zoom min/max values #238
+- Add pagination to account assets #224
 
 ## 2.5.0
 

--- a/src/Pages/Accounts/Components/AccountAssets.js
+++ b/src/Pages/Accounts/Components/AccountAssets.js
@@ -1,16 +1,34 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Table } from 'Components';
+import { useParams } from 'react-router-dom';
 import { useAccounts, useAssets } from 'redux/hooks';
 
 const AccountAssets = () => {
-  // Spotlight pulls all account data including balances, no need to refetch in this Component
-  const { accountInfoLoading: tableLoading, accountAssets } = useAccounts();
+  const [tableCurrentPage, setTableCurrentPage] = useState(1);
+  const { addressId } = useParams();
+  const {
+    accountAssets,
+    accountAssetsTotal,
+    accountAssetsPages: tablePages,
+    getAccountAssets: getTableData,
+    accountAssetsLoading: tableLoading,
+  } = useAccounts();
+
   const { assetMetadata } = useAssets();
 
+  // Build table data
   const tableData = accountAssets.map(a => ({
     ...a,
     displayDenom: assetMetadata.find(md => md.base === a.denom)?.display,
   }));
+
+  useEffect(() => {
+    getTableData({
+      address: addressId,
+      page: tableCurrentPage,
+      count: 10,
+    });
+  }, [getTableData, tableCurrentPage, addressId]);
 
   // Table header values in order
   const tableHeaders = [
@@ -24,8 +42,11 @@ const AccountAssets = () => {
     <Table
       tableHeaders={tableHeaders}
       tableData={tableData}
+      currentPage={tableCurrentPage}
+      changePage={setTableCurrentPage}
+      totalPages={tablePages}
       isLoading={tableLoading}
-      title="Account Assets"
+      title={`Account Assets (${accountAssetsTotal} total)`}
     />
   );
 };

--- a/src/Pages/Accounts/Components/AccountSpotlight.js
+++ b/src/Pages/Accounts/Components/AccountSpotlight.js
@@ -24,7 +24,7 @@ const AccountSpotlight = () => {
   const [showAUMPopup, setShowAUMPopup] = useState(false);
 
   useEffect(() => {
-    getAccountAssets(addressId);
+    getAccountAssets({ address: addressId });
     getAccountInfo(addressId);
   }, [getAccountAssets, getAccountInfo, addressId]);
 

--- a/src/Pages/Dashboard/Components/HashDashboard.js
+++ b/src/Pages/Dashboard/Components/HashDashboard.js
@@ -82,7 +82,7 @@ const HashDashboard = () => {
               })}    `}
               <HashSpan>
                 (
-                <PercentChange color={priceChangePercent < 0 ? 'red' : 'rgb(78, 210, 44)'}>
+                <PercentChange color={priceIncrease ? 'rgb(78, 210, 44)' : 'red'}>
                   {priceChangePercent}
                 </PercentChange>
                 )

--- a/src/redux/actions/accountsActions.js
+++ b/src/redux/actions/accountsActions.js
@@ -15,8 +15,14 @@ export const GET_ACCOUNT_UNBONDING = 'ACCOUNTS::GET_ACCOUNT_UNBONDING';
 export const getAccountInfo = address => async dispatch =>
   ajaxGet(GET_ACCOUNT_INFO, dispatch, `${ACCOUNT_INFO_URL}/${address}`);
 
-export const getAccountAssets = address => async dispatch =>
-  ajaxGet(GET_ACCOUNT_ASSETS, dispatch, `${ACCOUNT_INFO_URL}/${address}/balances`);
+export const getAccountAssets =
+  ({ address, page = 1, count = 10 }) =>
+  async dispatch =>
+    ajaxGet(
+      GET_ACCOUNT_ASSETS,
+      dispatch,
+      `${ACCOUNT_INFO_URL}/${address}/balances?page=${page}&count=${count}`
+    );
 
 export const getAccountDelegations =
   ({ address, page = 1, count = 10 }) =>

--- a/src/redux/hooks/useStaking.js
+++ b/src/redux/hooks/useStaking.js
@@ -67,7 +67,7 @@ const useStaking = () => {
     (async () => {
       try {
         if (shouldPull && isLoggedIn) {
-          getAccountAssets(delegatorAddress);
+          getAccountAssets({ address: delegatorAddress });
           getAccountDelegations({ address: delegatorAddress, count: 100, page: 1 });
           getAccountRedelegations(delegatorAddress);
           getAccountUnbonding(delegatorAddress);

--- a/src/redux/reducers/accountsReducer.js
+++ b/src/redux/reducers/accountsReducer.js
@@ -24,6 +24,7 @@ export const initialState = {
   accountAssetsLoading: false,
   accountAssets: [],
   accountAssetsPages: 0,
+  accountAssetsTotal: 0,
   // Account Delegations
   accountDelegationsLoading: false,
   accountDelegations: [],
@@ -80,7 +81,11 @@ const reducer = handleActions(
       };
     },
     [`${GET_ACCOUNT_ASSETS}_${SUCCESS}`](state, { payload }) {
-      const { pages: accountAssetsPages, results: accountAssets = [] } = payload;
+      const {
+        pages: accountAssetsPages,
+        results: accountAssets = [],
+        total: accountAssetsTotal,
+      } = payload;
       return {
         ...state,
         accountAssetsLoading: false,
@@ -100,6 +105,7 @@ const reducer = handleActions(
             : '-- --',
         })),
         accountAssetsPages,
+        accountAssetsTotal,
       };
     },
     [`${GET_ACCOUNT_ASSETS}_${FAILURE}`](state) {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before submitting, please review the checkboxes.
v    If a checkbox is n/a - please still include it but add a note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

This PR adds pagination to the account assets page, as well as corrects a minor issue with red/green font on the dashboard hash % change.

closes: #224 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [X] Targeted PR against correct branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [X] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [X] Re-reviewed `Files changed` in the Github PR explorer