### PR TITLE
Removes margins from standalone hash stats page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - Add Figure test wallets to User Login component #445
 - Add maintenance page #371
 - Remove maintenance page from being the only displayed page #461
+- Add standalone hash stats page #465
+- Remove standlone hash stats page margins #467
 
 ## Kurbat Ivanov
 

--- a/src/Pages/HashStats/HashStats.tsx
+++ b/src/Pages/HashStats/HashStats.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { Section, Wrapper } from 'Components';
+import { Section } from 'Components';
 import { HashDashboard, PriceHistory } from 'Pages/Dashboard/Components';
 
 const Background = styled.div`
@@ -14,11 +14,9 @@ const Background = styled.div`
 
 export const HashStats = () => (
   <Background>
-    <Wrapper noHeader>
-      <Section>
-        <HashDashboard />
-        <PriceHistory />
-      </Section>
-    </Wrapper>
+    <Section>
+      <HashDashboard />
+      <PriceHistory />
+    </Section>
   </Background>
 );


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before submitting, please review the checkboxes.
v    If a checkbox is n/a - please still include it but add a note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Removes margins from hash stats page

closes: #467 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [X] Targeted PR against correct branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [X] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [X] Re-reviewed `Files changed` in the Github PR explorer