### PR TITLE
Always Show WalletConnect Mobile QR

### DIFF
--- a/src/Providers/CosmosProvider.tsx
+++ b/src/Providers/CosmosProvider.tsx
@@ -92,7 +92,11 @@ export const CosmosProvider = ({ children }: { children: React.ReactNode }) => {
             },
           },
         }}
-        walletConnectOptions={{
+      modalOptions={{
+      mobile: { displayQRCodeEveryTime: true }
+    }}
+
+      walletConnectOptions={{
           signClient: {
             projectId: '6451479b4eb6d2967465521cb99ff677',
             relayUrl: 'wss://relay.walletconnect.org',
@@ -102,6 +106,7 @@ export const CosmosProvider = ({ children }: { children: React.ReactNode }) => {
               url: 'https://explorer.provenance.io/',
               icons: [],
             },
+            autoConnect: false,
           },
         }}
         // @ts-ignore


### PR DESCRIPTION
## Description

Recommendation from Arculus team: fix to always show QR modal to fix Arculus reconnect/timeout issue.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer